### PR TITLE
fix(frontend): 修复错误提示 overlay innerHTML XSS 注入

### DIFF
--- a/frontend-react/src/main.tsx
+++ b/frontend-react/src/main.tsx
@@ -43,14 +43,20 @@ const showDebugOverlay = (entry: { kind: string; message: string; stack?: string
     'white-space:pre-wrap', 'word-break:break-all',
   ].join(';');
   const stack = entry.stack || '(no stack)';
+  // 安全方式构建 DOM，避免 innerHTML 拼接导致的 XSS
+  const esc = (s: string) => {
+    const el = document.createElement('span');
+    el.textContent = s;
+    return el.innerHTML;
+  };
   box.innerHTML = [
-    `<b style="color:#ff6b6b">[${entry.kind}] ${entry.message}</b>`,
+    `<b style="color:#ff6b6b">[${esc(entry.kind)}] ${esc(entry.message)}</b>`,
     ``,
-    `<b>Time:</b> ${entry.time}`,
-    `<b>URL:</b> ${entry.url}`,
+    `<b>Time:</b> ${esc(entry.time)}`,
+    `<b>URL:</b> ${esc(entry.url)}`,
     ``,
     `<b>Stack:</b>`,
-    stack,
+    esc(stack),
     ``,
     `<i style="color:#888">已写入 localStorage.mobile_errors</i>`,
     ``,


### PR DESCRIPTION
## 问题
`frontend-react/src/main.tsx` 的 `showDebugOverlay` 函数用 `innerHTML` 拼接 `entry.message`、`entry.stack` 等用户可控数据。若错误消息含 HTML 标签（如 `<img onerror=...>`），可被注入执行恶意脚本。

## 改法
添加 `esc()` 函数，通过 `textContent` → `innerHTML` 转换对所有动态字段做 HTML 实体转义后再拼接，保持样式和功能完全不变。

## 验证
- `npx tsc -b` 类型检查通过
- 转义逻辑仅影响数据展示，不影响按钮事件和样式