### PR TITLE
perf(frontend): 移除 index.html 禁用缓存 meta 标签

### DIFF
--- a/frontend-react/index.html
+++ b/frontend-react/index.html
@@ -17,10 +17,6 @@
         }
       })();
     </script>
-    <!-- 禁用缓存 -->
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>省心投平台 - 互联网广告投放分析平台</title>
     <!-- Favicon -->
     <link rel="icon" href="favicon.ico" type="image/x-icon">


### PR DESCRIPTION
## 问题
`frontend-react/index.html` 第 20-23 行包含三个禁用缓存的 meta 标签：
```html
<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
<meta http-equiv="Pragma" content="no-cache">
<meta http-equiv="Expires" content="0">
```

Vite 构建产物文件名带内容指纹（hash），全局禁用缓存会导致每次页面加载都重新请求所有资源，有害无益。

## 改法
删除这三个 meta 标签（及注释行），让浏览器正常使用 Vite 的缓存策略。

## 验证
- `npm run build` 成功
- 构建产物文件名带 hash，缓存策略合理