### PR TITLE
fix(backend): CORS 配置从通配符改为白名单

### DIFF
--- a/app.py
+++ b/app.py
@@ -122,7 +122,17 @@ app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 0
 app.config['TEMPLATES_AUTO_RELOAD'] = True
 
 # CORS配置 - 使用Flask-CORS扩展（推荐）
-CORS(app, resources={r"/api/*": {"origins": "*", "headers": "Content-Type,Authorization", "methods": "GET,PUT,POST,DELETE,OPTIONS", "supports_credentials": True}})
+# 本地开发环境使用白名单，支持通过 CORS_ORIGINS 环境变量扩展（逗号分隔）
+_default_cors_origins = [
+    "http://localhost:5173",   # Vite 开发服务器
+    "http://127.0.0.1:5173",  # Vite 开发服务器（IP 形式）
+    "http://localhost:5000",   # Flask 后端
+    "http://127.0.0.1:5000",  # Flask 后端（IP 形式）
+]
+_extra_origins = os.getenv('CORS_ORIGINS', '').strip()
+if _extra_origins:
+    _default_cors_origins.extend([o.strip() for o in _extra_origins.split(',') if o.strip()])
+CORS(app, resources={r"/api/*": {"origins": _default_cors_origins, "headers": "Content-Type,Authorization", "methods": "GET,PUT,POST,DELETE,OPTIONS", "supports_credentials": True}})
 
 # ============================================================================
 # Swagger/OpenAPI 文档配置


### PR DESCRIPTION
## 问题
`app.py` 第 125 行 CORS 配置使用 `origins: "*"` 通配符，允许任何来源跨域访问 API，且同时设置了 `supports_credentials: True`，这在浏览器端会被拒绝（规范不允许 credentials + *）。

## 改法
- 将 origins 从 `"*"` 改为本地开发环境白名单
- 白名单包含 Vite 开发服务器 (5173) 和 Flask 后端 (5000) 的 localhost/127.0.0.1
- 支持通过 `CORS_ORIGINS` 环境变量扩展额外的 origin（逗号分隔）
- 提升安全性，避免生产环境意外开放跨域访问

## 验证
- `python3 -m py_compile app.py` 语法检查通过