### PR TITLE
fix(backend): 移除硬编码默认管理员密码

### DIFF
--- a/app.py
+++ b/app.py
@@ -702,8 +702,12 @@ with app.app_context():
             from backend.auth.jwt_utils import hash_password
             from datetime import datetime
             if AppUser.query.count() == 0:
+                import secrets
                 admin_email = top_config.DEFAULT_ADMIN_EMAIL
                 admin_password = top_config.DEFAULT_ADMIN_PASSWORD
+                if not admin_password:
+                    admin_password = secrets.token_urlsafe(12)
+                    logger.warning(f"⚠ DEFAULT_ADMIN_PASSWORD 未配置，已生成随机密码（请妥善保存并尽快修改）")
                 admin = AppUser(
                     email=admin_email,
                     password_hash=hash_password(admin_password),
@@ -717,6 +721,8 @@ with app.app_context():
                 db.session.add(admin)
                 db.session.commit()
                 logger.info(f"✓ 默认 admin 账号已创建：{admin_email}（请尽快修改密码）")
+                if not top_config.DEFAULT_ADMIN_PASSWORD:
+                    logger.info(f"✓ 默认管理员初始密码：{admin_password}")
             else:
                 logger.debug("app_users 表已有用户，跳过默认 admin 创建")
         except Exception as e:

--- a/config.py
+++ b/config.py
@@ -148,8 +148,9 @@ JWT_EXPIRES_HOURS = float(os.getenv('JWT_EXPIRES_HOURS', '24'))
 
 # feat-local-auth 方案 A：默认 admin 账号
 # 首次启动时，如果 app_users 表为空，自动创建此账号
+# 密码未配置时为空串，app.py 会在创建时生成随机密码并打印到日志
 DEFAULT_ADMIN_EMAIL = os.getenv('DEFAULT_ADMIN_EMAIL', 'admin@shengxintou.local')
-DEFAULT_ADMIN_PASSWORD = os.getenv('DEFAULT_ADMIN_PASSWORD', 'shengxintou2026')
+DEFAULT_ADMIN_PASSWORD = os.getenv('DEFAULT_ADMIN_PASSWORD', '')
 
 # 文件上传配置
 # v3.5.8：桌面版上传目录也放 USER_DATA_DIR（升级不丢失临时上传文件）


### PR DESCRIPTION
## 问题
`config.py` 第 152 行硬编码了默认管理员密码 `shengxintou2026`，存在安全风险。

## 改法
- `config.py`: `DEFAULT_ADMIN_PASSWORD` 默认值从硬编码改为空字符串
- `app.py`: 当密码未配置时，使用 `secrets.token_urlsafe(12)` 自动生成随机密码并打印到启动日志
- 提升安全性，避免默认密码泄露风险
- 用户需通过环境变量或日志获取初始密码后尽快修改

## 验证
- `python3 -m py_compile config.py` 语法检查通过
- `python3 -m py_compile app.py` 语法检查通过