### PR TITLE
fix(ci/android): tag 推送触发 CI + APK 注入真实版本号

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ name: CI
 on:
   push:
     branches: [main, master]
+    tags: ['v*']
   pull_request:
     branches: [main, master]
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,6 +24,8 @@ concurrency:
 
 jobs:
   deploy:
+    # tag 推送不部署 Pages（github-pages 环境禁止 tag 部署），仅 main 分支推送部署
+    if: github.ref_type == 'branch'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/android/scripts/post-sync-patch.ps1
+++ b/android/scripts/post-sync-patch.ps1
@@ -316,7 +316,49 @@ os.replace(tmp, dst)
 
 Write-Output "[done] post-sync-patch complete"
 
-# ========== 9. 打包后复制 APK（shengxintou 命名） ==========
+# ========== 10. 注入 APK 版本号到 build.gradle ==========
+# v3.8.6 修复：build-apk.ps1 从 version.json 读版本只用于重命名文件，
+# 但 Capacitor 生成的 build.gradle 里 versionName/versionCode 保持默认 1.0/1，
+# 导致安装后显示 1.0，无法覆盖升级安装。
+#
+# versionCode 编码方案：yyyyMMddHH（年月日时，如 2026081610 表示 2026-08-16 10:00）
+#   - 单调递增：只要打包时间晚于上次，code 必然大于上次
+#   - 历史安全：v3.8.4 已发布，假设其 code 最大为 2026081523（2026-08-15 23:00），
+#     新 code 从 2026081600 起必然大于历史所有 code
+#   - 容量充足：yyyyMMddHH 格式到 2099 年都不会溢出（最大 2099123123）
+$versionJsonPath = Join-Path $PSScriptRoot "..\..\version.json"
+$buildGradlePath = Join-Path $androidNativeDir "app\build.gradle"
+if (Test-Path $versionJsonPath) {
+    $versionJson = Get-Content $versionJsonPath -Raw | ConvertFrom-Json
+    $versionName = $versionJson.version
+    $versionCode = Get-Date -Format "yyyyMMddHH"
+    if (Test-Path $buildGradlePath) {
+        $gradle = Read-FileNoBom $buildGradlePath
+        $changed = $false
+        # 替换 versionName（可能是 versionName "1.0" 或 versionName = "1.0"）
+        if ($gradle -match 'versionName\s+["\'][^"\']+["\']') {
+            $gradle = $gradle -replace 'versionName\s+["\'][^"\']+["\']', "versionName `"$versionName`""
+            $changed = $true
+        }
+        # 替换 versionCode（可能是 versionCode 1 或 versionCode = 1）
+        if ($gradle -match 'versionCode\s+\d+') {
+            $gradle = $gradle -replace 'versionCode\s+\d+', "versionCode $versionCode"
+            $changed = $true
+        }
+        if ($changed) {
+            Write-FileNoBom $buildGradlePath $gradle
+            Write-Output "[patch] build.gradle: versionName=$versionName, versionCode=$versionCode (yyyyMMddHH)"
+        } else {
+            Write-Output "[warn] build.gradle: versionName/versionCode pattern not found"
+        }
+    } else {
+        Write-Output "[skip] build.gradle not found at $buildGradlePath (run cap sync first)"
+    }
+} else {
+    Write-Output "[warn] version.json not found at $versionJsonPath"
+}
+
+# ========== 11. 打包后复制 APK（shengxintou 命名） ==========
 # build.gradle 中 outputFileName 用 ASCII（shengxintou-vX.Y.Z.apk），
 # 打包完成后由本函数复制到 android/release/，保持 shengxintou 拼音命名
 # v3.5.3：改用 assembleDebug（debug keystore 自动签名），默认搜 debug 目录


### PR DESCRIPTION
## 根因分析

### 任务1：v3.8.5 tag CI 红叉
- **现象**：v3.8.5 tag（commit 41a9b90c）上 main 分支 CI 全绿，但 tag 显示红叉
- **根因**：`pages.yml` 的 deploy job 在 tag push 时触发，但 `github-pages` environment 禁止 tag 部署，导致 deploy 失败（check run id=95085409662，conclusion=failure）
- **修复**：
  1. `ci.yml` 增加 `push: tags: [v*]` 触发条件，让 tag 提交也有 CI 结论
  2. `pages.yml` deploy job 增加 `if: github.ref_type == branch` 条件，tag push 时跳过部署

### 任务2：APK 安装显示 1.0，无法升级
- **根因**：`build-apk.ps1` 从 version.json 读版本只用于重命名文件，但 Capacitor 生成的 `android/android/app/build.gradle` 里 versionName/versionCode 保持默认 1.0/1
- **修复**：`post-sync-patch.ps1` 增加第 10 步，从 version.json 读版本号，注入 build.gradle：
  - versionName：直接使用 version.json 的 version 字段（如 3.8.5）
  - versionCode：yyyyMMddHH 编码（如 2026081610），单调递增保证新版本 > 旧版本

## 修改文件
- `.github/workflows/ci.yml`：增加 tag 触发
- `.github/workflows/pages.yml`：deploy job 增加 branch-only 条件
- `android/scripts/post-sync-patch.ps1`：增加版本号注入逻辑

## 验证
- ci.yml 语法正确（YAML lint 通过）
- pages.yml 条件表达式正确
- post-sync-patch.ps1 逻辑：读 version.json → 计算 versionCode → 正则替换 build.gradle 的 versionName/versionCode