### PR TITLE
hotfix(android): 修复 APK 版本注入段 PowerShell 语法错误（v3.8.6 构建失败）

### DIFF
--- a/android/scripts/post-sync-patch.ps1
+++ b/android/scripts/post-sync-patch.ps1
@@ -335,9 +335,9 @@ if (Test-Path $versionJsonPath) {
     if (Test-Path $buildGradlePath) {
         $gradle = Read-FileNoBom $buildGradlePath
         $changed = $false
-        # 替换 versionName（可能是 versionName "1.0" 或 versionName = "1.0"）
-        if ($gradle -match 'versionName\s+["\'][^"\']+["\']') {
-            $gradle = $gradle -replace 'versionName\s+["\'][^"\']+["\']', "versionName `"$versionName`""
+        # 替换 versionName（Capacitor 生成格式：versionName "1.0"）
+        if ($gradle -match 'versionName\s+"[^"]+"') {
+            $gradle = $gradle -replace 'versionName\s+"[^"]+"', "versionName `"$versionName`""
             $changed = $true
         }
         # 替换 versionCode（可能是 versionCode 1 或 versionCode = 1）


### PR DESCRIPTION
## 根因

v3.8.6 APK 构建失败：#20 注入的版本段在单引号字符串里用了 `\'` 转义，而 PowerShell 单引号串不支持反斜杠转义（只支持 `''`），post-sync-patch.ps1 解析直接报错。

## 修复

改用不含撇号的双引号匹配正则 `versionName\s+"[^"]+"`（Capacitor 生成的 build.gradle 固定使用双引号）。已通过引号/括号配对校验。