### PR TITLE
fix(backend/mobile): 主播周度汇总 weekly_agg 补复合来源均分

### DIFF
--- a/backend/routes/data/leads.py
+++ b/backend/routes/data/leads.py
@@ -748,11 +748,11 @@ def get_anchor_weekly_analysis():
             w['new_opened'] += round(int(r.new_opened or 0) / div)
             w['new_valid'] += round(int(r.new_valid or 0) / div)
 
-            # 整体周度汇总
+            # 整体周度汇总（v3.8.7: 同步均分，避免 weekly_totals > 各主播之和）
             if week not in weekly_agg:
                 weekly_agg[week] = {'leads': 0, 'mouth': 0, 'valid_lead': 0, 'new_valid_lead': 0, 'new_opened': 0, 'new_valid': 0}
             for k in ('leads', 'mouth', 'valid_lead', 'new_valid_lead', 'new_opened', 'new_valid'):
-                weekly_agg[week][k] += int(getattr(r, k) or 0)
+                weekly_agg[week][k] += round(int(getattr(r, k) or 0) / div)
 
     # 组装 anchor_items + 派生率
     anchor_items = []

--- a/frontend-react/src/services/mobileHandlers/leads.ts
+++ b/frontend-react/src/services/mobileHandlers/leads.ts
@@ -680,13 +680,14 @@ export async function handleAnchorWeeklyAnalysis(body: any): Promise<any> {
       if (!weeklyAgg[week]) {
         weeklyAgg[week] = { leads: 0, mouth: 0, valid_lead: 0, new_valid_lead: 0, new_opened: 0, new_valid: 0 };
       }
+      // v3.8.7: 同步均分，避免 weekly_totals > 各主播之和（与后端 leads.py 一致）
       const wa = weeklyAgg[week];
-      wa.leads += toInt(r.leads);
-      wa.mouth += toInt(r.mouth);
-      wa.valid_lead += toInt(r.valid_lead);
-      wa.new_valid_lead += toInt(r.new_valid_lead);
-      wa.new_opened += toInt(r.new_opened);
-      wa.new_valid += toInt(r.new_valid);
+      wa.leads += Math.round(toInt(r.leads) / div);
+      wa.mouth += Math.round(toInt(r.mouth) / div);
+      wa.valid_lead += Math.round(toInt(r.valid_lead) / div);
+      wa.new_valid_lead += Math.round(toInt(r.new_valid_lead) / div);
+      wa.new_opened += Math.round(toInt(r.new_opened) / div);
+      wa.new_valid += Math.round(toInt(r.new_valid) / div);
     }
   }
 


### PR DESCRIPTION
## 问题

backend/routes/data/leads.py:751-755 的 weekly_agg（整体周度走势）直接累加原始值，未按复合来源主播数均分，而主播维度 anchor_map 做了均分，导致 weekly_totals 线索数 > 各主播线索总和，数据矛盾。

## 改动

- 后端 leads.py：weekly_agg 累加改为 round(值 / div)，与 anchor_map 口径一致
- 移动端 leads.ts（handleAnchorWeeklyAnalysis）同步相同逻辑

## 验证

- check_api_contract.py / check_mobile_routes_coverage.py 无 drift（div 计数两端一致）
- py_compile 通过，tsc -b 通过
