### PR TITLE
fix(backend/mobile): anchor-clusters-trend 期间汇总补复合来源均分

### DIFF
--- a/backend/routes/data/leads.py
+++ b/backend/routes/data/leads.py
@@ -527,32 +527,38 @@ def get_anchor_clusters_trend():
     pp = defaultdict(lambda: defaultdict(lambda: {'leads':0,'new_leads':0,'mouth':0,'valid_lead':0,'new_opened':0,'new_valid':0,'new_assets':0.0}))
     all_platforms = set()
     SPLIT_PATTERN = re.compile(r"[,，;；、]+")
+    PATTERN = re.compile(r"^(视频号直播|视频号|抖音|小红书|快手|财联社|腾讯|微信)引流-(.+?)$")
     for r in rows:
+        src = (r.客户来源 or '').strip()
+        tokens = [t.strip() for t in SPLIT_PATTERN.split(src) if t.strip()]
         # live_types 筛选 — 拆 客户来源 token，看是否命中 wanted_tokens
         if live_types_filter:
-            src = (r.客户来源 or '').strip()
-            tokens = [t.strip() for t in SPLIT_PATTERN.split(src) if t.strip()]
             if not any(t in wanted_tokens for t in tokens):
                 continue
+        # 复合来源（如"抖音引流-周乐意,抖音引流-杨毅"）按匹配主播数均分，
+        # 与 anchor-clusters / anchor-weekly-analysis 口径一致，避免 period totals 虚高
+        matched = {t for t in tokens if PATTERN.match(t) or t in plain_name_tokens}
+        n = len(matched)
+        div = max(n, 1)
         period = r.period
         platform = r.platform or '未知'
         all_platforms.add(platform)
         b = pt[period]
-        b['leads'] += int(r.leads or 0)
-        b['new_leads'] += int(r.new_leads or 0)
-        b['mouth'] += int(r.mouth or 0)
-        b['valid_lead'] += int(r.valid_lead or 0)
-        b['new_opened'] += int(r.new_opened or 0)
-        b['new_valid'] += int(r.new_valid or 0)
-        b['new_assets'] += float(r.new_assets or 0)
+        b['leads'] += round(int(r.leads or 0) / div)
+        b['new_leads'] += round(int(r.new_leads or 0) / div)
+        b['mouth'] += round(int(r.mouth or 0) / div)
+        b['valid_lead'] += round(int(r.valid_lead or 0) / div)
+        b['new_opened'] += round(int(r.new_opened or 0) / div)
+        b['new_valid'] += round(int(r.new_valid or 0) / div)
+        b['new_assets'] += float(r.new_assets or 0) / div
         bx = pp[period][platform]
-        bx['leads'] += int(r.leads or 0)
-        bx['new_leads'] += int(r.new_leads or 0)
-        bx['mouth'] += int(r.mouth or 0)
-        bx['valid_lead'] += int(r.valid_lead or 0)
-        bx['new_opened'] += int(r.new_opened or 0)
-        bx['new_valid'] += int(r.new_valid or 0)
-        bx['new_assets'] += float(r.new_assets or 0)
+        bx['leads'] += round(int(r.leads or 0) / div)
+        bx['new_leads'] += round(int(r.new_leads or 0) / div)
+        bx['mouth'] += round(int(r.mouth or 0) / div)
+        bx['valid_lead'] += round(int(r.valid_lead or 0) / div)
+        bx['new_opened'] += round(int(r.new_opened or 0) / div)
+        bx['new_valid'] += round(int(r.new_valid or 0) / div)
+        bx['new_assets'] += float(r.new_assets or 0) / div
     periods = sorted(pt.keys())
     return jsonify({
         'success': True,
@@ -748,11 +754,11 @@ def get_anchor_weekly_analysis():
             w['new_opened'] += round(int(r.new_opened or 0) / div)
             w['new_valid'] += round(int(r.new_valid or 0) / div)
 
-            # 整体周度汇总
+            # 整体周度汇总（v3.8.7: 同步均分，避免 weekly_totals > 各主播之和）
             if week not in weekly_agg:
                 weekly_agg[week] = {'leads': 0, 'mouth': 0, 'valid_lead': 0, 'new_valid_lead': 0, 'new_opened': 0, 'new_valid': 0}
             for k in ('leads', 'mouth', 'valid_lead', 'new_valid_lead', 'new_opened', 'new_valid'):
-                weekly_agg[week][k] += int(getattr(r, k) or 0)
+                weekly_agg[week][k] += round(int(getattr(r, k) or 0) / div)
 
     # 组装 anchor_items + 派生率
     anchor_items = []

--- a/frontend-react/src/services/mobileHandlers/leads.ts
+++ b/frontend-react/src/services/mobileHandlers/leads.ts
@@ -478,12 +478,16 @@ export async function handleAnchorClustersTrend(body: any): Promise<any> {
   const allPlatforms = new Set<string>();
 
   for (const r of rows) {
+    const src = String(r.customer_source || '').trim();
+    const tokens = src.split(ANCHOR_SPLIT).map(t => t.trim()).filter(Boolean);
     // live_types 筛选 — 拆 客户来源 token，看是否命中 wanted_tokens
     if (wantedTokens) {
-      const src = String(r.customer_source || '').trim();
-      const tokens = src.split(ANCHOR_SPLIT).map(t => t.trim()).filter(Boolean);
       if (!tokens.some(t => wantedTokens.has(t))) continue;
     }
+    // 复合来源（如"抖音引流-周乐意,抖音引流-杨毅"）按匹配主播数均分，
+    // 与 anchor-clusters / anchor-weekly-analysis 口径一致，避免 period totals 虚高
+    const n = new Set(tokens.filter(t => ANCHOR_PATTERN.test(t) || ltMap.plain_name_tokens.has(t))).size;
+    const div = Math.max(n, 1);
     const period = String(r.period ?? '');
     const platform = String(r.platform || '未知');
     allPlatforms.add(platform);
@@ -492,26 +496,26 @@ export async function handleAnchorClustersTrend(body: any): Promise<any> {
       periodTotals[period] = { leads: 0, new_leads: 0, mouth: 0, valid_lead: 0, new_opened: 0, new_valid: 0, new_assets: 0 };
     }
     const b = periodTotals[period];
-    b.leads += toInt(r.leads);
-    b.new_leads += toInt(r.new_leads);
-    b.mouth += toInt(r.mouth);
-    b.valid_lead += toInt(r.valid_lead);
-    b.new_opened += toInt(r.new_opened);
-    b.new_valid += toInt(r.new_valid);
-    b.new_assets += toFloat(r.new_assets);
+    b.leads += Math.round(toInt(r.leads) / div);
+    b.new_leads += Math.round(toInt(r.new_leads) / div);
+    b.mouth += Math.round(toInt(r.mouth) / div);
+    b.valid_lead += Math.round(toInt(r.valid_lead) / div);
+    b.new_opened += Math.round(toInt(r.new_opened) / div);
+    b.new_valid += Math.round(toInt(r.new_valid) / div);
+    b.new_assets += toFloat(r.new_assets) / div;
 
     if (!byPlatform[period]) byPlatform[period] = {};
     if (!byPlatform[period][platform]) {
       byPlatform[period][platform] = { leads: 0, new_leads: 0, mouth: 0, valid_lead: 0, new_opened: 0, new_valid: 0, new_assets: 0 };
     }
     const bx = byPlatform[period][platform];
-    bx.leads += toInt(r.leads);
-    bx.new_leads += toInt(r.new_leads);
-    bx.mouth += toInt(r.mouth);
-    bx.valid_lead += toInt(r.valid_lead);
-    bx.new_opened += toInt(r.new_opened);
-    bx.new_valid += toInt(r.new_valid);
-    bx.new_assets += toFloat(r.new_assets);
+    bx.leads += Math.round(toInt(r.leads) / div);
+    bx.new_leads += Math.round(toInt(r.new_leads) / div);
+    bx.mouth += Math.round(toInt(r.mouth) / div);
+    bx.valid_lead += Math.round(toInt(r.valid_lead) / div);
+    bx.new_opened += Math.round(toInt(r.new_opened) / div);
+    bx.new_valid += Math.round(toInt(r.new_valid) / div);
+    bx.new_assets += toFloat(r.new_assets) / div;
   }
 
   const periods = Object.keys(periodTotals).sort();
@@ -680,13 +684,14 @@ export async function handleAnchorWeeklyAnalysis(body: any): Promise<any> {
       if (!weeklyAgg[week]) {
         weeklyAgg[week] = { leads: 0, mouth: 0, valid_lead: 0, new_valid_lead: 0, new_opened: 0, new_valid: 0 };
       }
+      // v3.8.7: 同步均分，避免 weekly_totals > 各主播之和（与后端 leads.py 一致）
       const wa = weeklyAgg[week];
-      wa.leads += toInt(r.leads);
-      wa.mouth += toInt(r.mouth);
-      wa.valid_lead += toInt(r.valid_lead);
-      wa.new_valid_lead += toInt(r.new_valid_lead);
-      wa.new_opened += toInt(r.new_opened);
-      wa.new_valid += toInt(r.new_valid);
+      wa.leads += Math.round(toInt(r.leads) / div);
+      wa.mouth += Math.round(toInt(r.mouth) / div);
+      wa.valid_lead += Math.round(toInt(r.valid_lead) / div);
+      wa.new_valid_lead += Math.round(toInt(r.new_valid_lead) / div);
+      wa.new_opened += Math.round(toInt(r.new_opened) / div);
+      wa.new_valid += Math.round(toInt(r.new_valid) / div);
     }
   }
 


### PR DESCRIPTION
## 问题

backend/routes/data/leads.py anchor-clusters-trend 端点的 period totals（pt）与 period×platform（pp）直接累加原始值，未做复合来源均分，与 anchor-clusters / anchor-weekly-analysis 的均分口径不一致，复合来源线索导致走势数据虚高。

## 改动

- 后端 leads.py：循环内解析 客户来源 tokens，按匹配主播数（引流 PATTERN 或 plain_name_tokens 命中）计算 div=max(n,1)，pt/pp 累加改为 round(值/div)（资产类直接 /div）
- 移动端 mobileHandlers/leads.ts handleAnchorClustersTrend：同步相同逻辑（Math.round(toInt(...)/div)）

## 验证

- python3 -m py_compile leads.py 通过
- npx tsc -b 通过
- scripts/check_api_contract.py 无新 drift，算法一致性通过（div 计数两端对齐）
